### PR TITLE
API: Remove returns void undefined

### DIFF
--- a/packages/api/src/server/ArchiveUtil/index.d.ts
+++ b/packages/api/src/server/ArchiveUtil/index.d.ts
@@ -10,7 +10,6 @@ export function createArchive(aParent: Node, aName: string): Node;
 
 /**
 * Alters the name of an archive.
-* @returns {void} undefined 
 * @param {Node} anArchive - the archive that should be renamed. May not be null
 * @param {string} aName - the new name of the archive. May not be null
 */

--- a/packages/api/src/server/ArticleUtil/index.d.ts
+++ b/packages/api/src/server/ArticleUtil/index.d.ts
@@ -45,7 +45,6 @@ export function createArticle(aParent: Node, aTemplate: Node, aName: string, pro
 
 /**
 * Alters the name of an article.
-* @returns {void} undefined 
 * @param {Node} anArticle - the article that should be renamed. May not be null
 * @param {string} aName - the new name of the article. May not be null
 */
@@ -53,7 +52,6 @@ export function renameArticle(anArticle: Node, aName: string): void;
 
 /**
 * Updates the properties of an article.
-* @returns {void} undefined 
 * @param {Node} anArticle - the sv:article that will be altered. May not be null
 * @param {Map<string, any>} properties - the article properties. May not be null
 */

--- a/packages/api/src/server/CollaborationGroupWrapper/index.d.ts
+++ b/packages/api/src/server/CollaborationGroupWrapper/index.d.ts
@@ -104,21 +104,18 @@ export interface ICollaborationGroupWrapper {
 
   /**
   * Sets the group description of the wrapped collaboration group.
-  * @returns {void} undefined 
   * @param {string} aGroupDescription - the collaboration group description
   */
   setGroupDescription(aGroupDescription: string): void;
 
   /**
   * Changes the collaboration group state of the wrapped collaboration group.
-  * @returns {void} undefined 
   * @param {CollaborationGroupState} aCollaborationGroupState - the collaboration group state
   */
   setGroupState(aCollaborationGroupState: CollaborationGroupState): void;
 
   /**
   * Changes the collaboration group type of the wrapped collaboration group.
-  * @returns {void} undefined 
   * @param {CollaborationGroupType} aCollaborationGroupType - the collaboration group type
   */
   setGroupType(aCollaborationGroupType: CollaborationGroupType): void;

--- a/packages/api/src/server/LogUtil/index.d.ts
+++ b/packages/api/src/server/LogUtil/index.d.ts
@@ -1,15 +1,13 @@
 import Throwable from '../../builtins/Throwable';
 
-  /**
-  * Logs a debug message to the Sitevision server log.
-  * @returns {void} undefined 
+/**
+* Logs a debug message to the Sitevision server log.
 * @param {string} aMessage - a message.
-  */
+*/
 export function debug(aMessage: string): void;
   
 /**
 * Logs a debug message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 * @param {Throwable} aThrowable - a throwable.
 */
@@ -17,14 +15,12 @@ export function debug(aMessage: string, aThrowable: Throwable): void;
 
 /**
 * Logs an error message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 */
 export function error(aMessage: string): void;
 
 /**
 * Logs an error message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 * @param {Throwable} aThrowable - a throwable.
 */
@@ -32,14 +28,12 @@ export function error(aMessage: string, aThrowable: Throwable): void;
 
 /**
 * Logs an info message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 */
 export function info(aMessage: string): void;
 
 /**
 * Logs an info message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 * @param {Throwable} aThrowable - a throwable.
 */
@@ -77,14 +71,12 @@ export function isWarnEnabled(): boolean;
 
 /**
 * Logs a trace message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 */
 export function trace(aMessage: string): void;
 
 /**
 * Logs a trace message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 * @param {Throwable} aThrowable - a throwable.
 */
@@ -92,14 +84,12 @@ export function trace(aMessage: string, aThrowable: Throwable): void;
 
 /**
 * Logs a warn message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 */
 export function warn(aMessage: string): void;
 
 /**
 * Logs a warn message to the Sitevision server log.
-* @returns {void} undefined 
 * @param {string} aMessage - a message.
 * @param {Throwable} aThrowable - a throwable.
 */
@@ -107,21 +97,16 @@ export function warn(aMessage: string, aThrowable: Throwable): void;
 
 declare namespace logUtil {
   export {
-    debug,
-    debug,
-    error,
-    error,
-    info,
-    info,
+    debug,   
+    error,  
+    info,   
     isDebugEnabled,
     isErrorEnabled,
     isInfoEnabled,
     isTraceEnabled,
     isWarnEnabled,
-    trace,
-    trace,
-    warn,
-    warn,
+    trace,   
+    warn,   
   };
 }
 


### PR DESCRIPTION
Remove `@returns {void} undefined` that accidentally was included on functions not returning anything.