### PR TITLE
Added possibility to use http on local development

### DIFF
--- a/packages/sitevision-scripts/scripts/create-addon.js
+++ b/packages/sitevision-scripts/scripts/create-addon.js
@@ -8,7 +8,7 @@ const chalk = require('chalk');
     properties.getAppType() === 'rest'
       ? 'headlesscustommodule'
       : 'custommodule';
-  const url = `https://${encodeURIComponent(
+  const url = (props.useHTTP ? `http://` : `https://`) + `${encodeURIComponent(
     props.username
   )}:${encodeURIComponent(props.password)}@${
     props.domain

--- a/packages/sitevision-scripts/scripts/create-addon.js
+++ b/packages/sitevision-scripts/scripts/create-addon.js
@@ -8,7 +8,7 @@ const chalk = require('chalk');
     properties.getAppType() === 'rest'
       ? 'headlesscustommodule'
       : 'custommodule';
-  const url = (props.useHTTP ? `http://` : `https://`) + `${encodeURIComponent(
+  const url = (props.useHTTPForDevDeploy ? `http://` : `https://`) + `${encodeURIComponent(
     props.username
   )}:${encodeURIComponent(props.password)}@${
     props.domain

--- a/packages/sitevision-scripts/scripts/deploy.js
+++ b/packages/sitevision-scripts/scripts/deploy.js
@@ -20,7 +20,7 @@ const chalk = require('chalk');
   const props = properties.getDevProperties();
   const restEndpoint =
     properties.getAppType() === 'rest' ? 'restAppImport' : 'webAppImport';
-  let url = (props.useHTTP ? `http://` : `https://`) + `${encodeURIComponent(props.username)}:${encodeURIComponent(
+  let url = (props.useHTTPForDevDeploy ? `http://` : `https://`) + `${encodeURIComponent(props.username)}:${encodeURIComponent(
     props.password
   )}@${props.domain}/rest-api/1/0/${encodeURIComponent(
     props.siteName

--- a/packages/sitevision-scripts/scripts/deploy.js
+++ b/packages/sitevision-scripts/scripts/deploy.js
@@ -20,7 +20,7 @@ const chalk = require('chalk');
   const props = properties.getDevProperties();
   const restEndpoint =
     properties.getAppType() === 'rest' ? 'restAppImport' : 'webAppImport';
-  let url = `https://${encodeURIComponent(props.username)}:${encodeURIComponent(
+  let url = (props.useHTTP ? `http://` : `https://`) + `${encodeURIComponent(props.username)}:${encodeURIComponent(
     props.password
   )}@${props.domain}/rest-api/1/0/${encodeURIComponent(
     props.siteName


### PR DESCRIPTION
Added possibility to use the scripts ”npm run create-addon” and ”npm run dev ” with local development with HTTP. Which is default when you run your own sitevison server locally.

 Added possibility to add a true/false variable (useHTTP) in .dev_properties.json. If the variable is not set it will run as usual. I did not add the ability to add the variable when creating a sitevision app, as this is not used as frequently.