### PR TITLE
configure Babel to work with Typescript

### DIFF
--- a/packages/babel-preset-react-server/index.js
+++ b/packages/babel-preset-react-server/index.js
@@ -1,5 +1,5 @@
 module.exports = function () {
   return {
-    presets: ['@babel/preset-env', '@babel/preset-react'],
+    presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
   };
 };

--- a/packages/babel-preset-react-server/package.json
+++ b/packages/babel-preset-react-server/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@babel/preset-env": "^7.20.2",
-    "@babel/preset-react": "^7.18.6"
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "7.18.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,7 +1080,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.18.6"
     "@babel/plugin-transform-react-pure-annotations" "^7.18.6"
 
-"@babel/preset-typescript@^7.18.6":
+"@babel/preset-typescript@7.18.6", "@babel/preset-typescript@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz#ce64be3e63eddc44240c6358daefac17b3186399"
   integrity sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==


### PR DESCRIPTION
- Configured Babel to work with Typescript

I got a '**Missing semicolon**' error message when writing a test in a Typescript webApp which was caused by that babel not configuring to work with Typescript.