### PR TITLE
fix(sitevision-scripts): use correct fileextension

### DIFF
--- a/packages/sitevision-scripts/config/webpack/webpack.config.js
+++ b/packages/sitevision-scripts/config/webpack/webpack.config.js
@@ -56,14 +56,22 @@ const getWebAppConfig = ({ cwd, dev, cssPrefix, outputPath }) => {
   const hooksEntry = getEntry('hooks', true);
   if (fs.existsSync(hooksEntry)) {
     config.push(
-      getServerStandaloneEntryConfig({ entry: hooksEntry, outputPath })
+      getServerStandaloneEntryConfig({
+        entry: hooksEntry,
+        outputPath,
+        outputFilename: 'hooks.js',
+      })
     );
   }
 
   const headlessEntry = getEntry('headless', true);
   if (fs.existsSync(headlessEntry)) {
     config.push(
-      getServerStandaloneEntryConfig({ entry: headlessEntry, outputPath })
+      getServerStandaloneEntryConfig({
+        entry: headlessEntry,
+        outputPath,
+        outputFilename: 'headless.js',
+      })
     );
   }
 

--- a/packages/sitevision-scripts/config/webpack/webpack.config.server-standalone-entry.js
+++ b/packages/sitevision-scripts/config/webpack/webpack.config.server-standalone-entry.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import {
   getJsModuleLoader,
   getBabelLoader,
@@ -7,13 +6,17 @@ import {
 } from './webpack.loaders.js';
 import { getExternals, getServerOptimization } from './utils.js';
 
-export const getServerStandaloneEntryConfig = ({ entry, outputPath }) => ({
+export const getServerStandaloneEntryConfig = ({
+  entry,
+  outputPath,
+  outputFilename,
+}) => ({
   mode: 'production',
   devtool: undefined,
   entry,
   output: {
     path: outputPath,
-    filename: path.basename(entry),
+    filename: outputFilename,
     iife: true,
   },
   resolve: {


### PR DESCRIPTION
Incorrect output filenames could occur for typescript projects when using hooks och headless.