### PR TITLE
Update .gitignore

### DIFF
--- a/packages/sitevision-scripts/.gitignore
+++ b/packages/sitevision-scripts/.gitignore
@@ -1,3 +1,27 @@
+# WebApp / RestApp template folders excludes
 node_modules
-.idea
-.vscode
+build
+dist
+
+#VSCode excludes
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Common IntelliJ Platform excludes
+ 
+# User specific
+**/.idea/**/workspace.xml
+**/.idea/**/tasks.xml
+**/.idea/shelf/*
+**/.idea/dictionaries
+**/.idea/httpRequests/
+ 
+# Rider
+# Rider auto-generates .iml files, and contentModel.xml
+**/.idea/**/*.iml
+**/.idea/**/contentModel.xml
+**/.idea/**/modules.xml


### PR DESCRIPTION
Hi!

In commonly used web projects are these folders excluded for vscode and Intellij. For build and `dist` that is `build` artifacts do we need to exclude everytime for any RestApp/WebApp we create. These changes would simplify our workflow :)

Updated gitignore with common webstandard for vscode and Intellij. Also exclude build and dist.

 
