### PR TITLE
Issue 145 - Fix type on getNodeOutput

### DIFF
--- a/packages/api/src/public-api/server/OutputUtil/index.d.ts
+++ b/packages/api/src/public-api/server/OutputUtil/index.d.ts
@@ -295,7 +295,7 @@ export interface OutputUtil extends OutputUtilConstants {
    */
   getNodeOutput(
     aPageNode: Node,
-    aPagePartNode: Node,
+    aPagePartNode: Node | null,
     aContentType: number
   ): string;
 


### PR DESCRIPTION
Fixes #145

Update the TypeScript type definition for `getNodeOutput` method in `OutputUtil`.

* Modify the function signature to allow `aPagePartNode` to be `Node | null` instead of just `Node`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sitevision/sitevision-apps/pull/146?shareId=ed36c742-9e74-489e-a5c0-6b3ee8cfc1dd).