### PR TITLE
Add named exports to hooks and headless

### DIFF
--- a/packages/api/src/server/headless/index.d.ts
+++ b/packages/api/src/server/headless/index.d.ts
@@ -97,3 +97,15 @@ declare namespace Headless {}
 declare var headless: Headless;
 
 export default headless;
+
+export declare function getHeadlessContent(
+  callback: (
+    params: HeadlessContentParams
+  ) => (
+    | HeadlessImageContent
+    | HeadlessImagesContent
+    | HeadlessVideoContent
+    | HeadlessTextContent
+    | HeadlessFilesContent
+  )[]
+): void;

--- a/packages/api/src/server/hooks/index.d.ts
+++ b/packages/api/src/server/hooks/index.d.ts
@@ -14,9 +14,8 @@ export interface HooksResponse {
 
 export interface Hooks {
   beforeRender(callback: (req: Request, res: HooksResponse) => void): void;
-
-  getPageTitle(callback: (req: Request) => string);
-  addHeadElement(callback: (req: Request) => string);
+  getPageTitle(callback: (req: Request) => string): void;
+  addHeadElement(callback: (req: Request) => string): void;
 }
 
 declare namespace Hooks {}
@@ -24,3 +23,7 @@ declare namespace Hooks {}
 declare var hooks: Hooks;
 
 export default hooks;
+
+export declare function beforeRender(callback: (req: Request, res: HooksResponse) => void): void;
+export declare function getPageTitle(callback: (req: Request) => string): void;
+export declare function addHeadElement(callback: (req: Request) => string): void;


### PR DESCRIPTION
The code examples for [hooks.js](https://developer.sitevision.se/docs/webapps/getting-started/hooks.js) and [headless.js](https://developer.sitevision.se/docs/webapps/getting-started/headless.js) are using named exports that doesn't exist in `@sitevision/api/server/hooks` and `@sitevision/api/server/headless`, this PR adds them.