### PR TITLE
fix: Change return type

### DIFF
--- a/packages/api/src/server/storage/index.d.ts
+++ b/packages/api/src/server/storage/index.d.ts
@@ -14,7 +14,7 @@ export interface CollectionDataStore {
   addAll(data: any[]): void;
   get(dsid: string): unknown;
   set(dsid: string, data: any): void;
-  remove(dsid: string): void;
+  remove(dsid: string): unknown;
   removeAll(): void;
 
   find(query: string, options?: FindOptions): SearchResult;


### PR DESCRIPTION
Issue found during CSSD Training course. The `CollectionDataStore .remove` method returnes the removed record.