### PR TITLE
feat(api): Add generics to Filter

### DIFF
--- a/packages/api/src/public-api/server/CompoundAndFilterBuilder/index.d.ts
+++ b/packages/api/src/public-api/server/CompoundAndFilterBuilder/index.d.ts
@@ -36,7 +36,7 @@ export interface CompoundAndFilterBuilder extends Builder {
    * @param aFilter the node filter to add, <code>null</code> will be ignored
    * @return this builder
    */
-  addFilter(aFilter: Filter): CompoundAndFilterBuilder;
+  addFilter(aFilter: Filter<Node>): CompoundAndFilterBuilder;
 
   /**
    * Removes all previously added filters.
@@ -49,7 +49,7 @@ export interface CompoundAndFilterBuilder extends Builder {
    * @return a node filter
    * @throws IllegalStateException if this builder contains no filters.
    */
-  build(): Filter;
+  build(): Filter<Node>;
 }
 
 declare namespace CompoundAndFilterBuilder {}

--- a/packages/api/src/public-api/server/CompoundOrFilterBuilder/index.d.ts
+++ b/packages/api/src/public-api/server/CompoundOrFilterBuilder/index.d.ts
@@ -35,7 +35,7 @@ export interface CompoundOrFilterBuilder extends Builder {
    * @param aFilter the node filter to add, <code>null</code> will be ignored
    * @return this builder
    */
-  addFilter(aFilter: Filter): CompoundOrFilterBuilder;
+  addFilter(aFilter: Filter<Node>): CompoundOrFilterBuilder;
 
   /**
    * Removes all previously added filters.
@@ -48,7 +48,7 @@ export interface CompoundOrFilterBuilder extends Builder {
    * @return a node filter
    * @throws IllegalStateException if this builder contains no filters.
    */
-  build(): Filter;
+  build(): Filter<Node>;
 }
 
 declare namespace CompoundOrFilterBuilder {}

--- a/packages/api/src/public-api/server/NodeFilterUtil/index.d.ts
+++ b/packages/api/src/public-api/server/NodeFilterUtil/index.d.ts
@@ -110,7 +110,7 @@ export interface NodeFilterUtil {
    * @param aNodeFilter a node filter
    * @return a list of all nodes of <code>aNodeList</code> that is accepted by <code>aNodeFilter</code>, never <code>null</code>.&#xA; <code>aNodeList</code> itself is returned if it's empty or if <code>aNodeFilter</code> is <code>null</code>
    */
-  getFilteredList(aNodeList: List | unknown[], aNodeFilter: Filter): List;
+  getFilteredList(aNodeList: List | unknown[], aNodeFilter: Filter<Node>): List;
 
   /**
    * Applies a node filter to a Map with Node values and gets the result.
@@ -119,7 +119,7 @@ export interface NodeFilterUtil {
    * @return a Map with all <code>aNodeValueMap</code> entries with a value that is accepted by <code>aNodeFilter</code>, never <code>null</code>.&#xA; <code>aNodeValueMap</code> itself is returned if it's empty or if <code>aNodeFilter</code> is <code>null</code>
    * @since Sitevision 4.3.1
    */
-  getFilteredValueMap(aNodeValueMap: Map | {}, aNodeFilter: Filter): Map;
+  getFilteredValueMap(aNodeValueMap: Map | {}, aNodeFilter: Filter<Node>): Map;
 
   /**
    * Applies a node filter to a Map with Node keys and gets the result.
@@ -128,7 +128,7 @@ export interface NodeFilterUtil {
    * @return a Map with all <code>aNodeKeyMap</code> entries with a key that is accepted by <code>aNodeFilter</code>, never <code>null</code>.&#xA; <code>aNodeKeyMap</code> itself is returned if it's empty or if <code>aNodeFilter</code> is <code>null</code>
    * @since Sitevision 4.3.1
    */
-  getFilteredKeyMap(aNodeKeyMap: Map | {}, aNodeFilter: Filter): Map;
+  getFilteredKeyMap(aNodeKeyMap: Map | {}, aNodeFilter: Filter<Node>): Map;
 
   /**
    * Gets the filtering result of a split operation for a collection of nodes with a node filter as divider.
@@ -151,7 +151,7 @@ export interface NodeFilterUtil {
    */
   split(
     aNodeCollection: Collection | unknown[],
-    aNodeFilter: Filter
+    aNodeFilter: Filter<Node>
   ): FilterSplit;
 
   /**
@@ -181,27 +181,27 @@ export interface NodeFilterUtil {
    * Gets a filter that always matches.
    * @return a filter that matches all nodes.
    */
-  getAlwaysAcceptFilter(): Filter;
+  getAlwaysAcceptFilter(): Filter<Node>;
 
   /**
    * Gets a filter that never matches.
    * @return a filter that never matches any nodes.
    */
-  getNeverAcceptFilter(): Filter;
+  getNeverAcceptFilter(): Filter<Node>;
 
   /**
    * Gets a filter that matches null nodes.
    * @return a filter that matches null nodes.
    * @since Sitevision 4.3.1
    */
-  getNullFilter(): Filter;
+  getNullFilter(): Filter<Node>;
 
   /**
    * Gets a filter that matches non-null nodes.
    * @return a filter that matches non-null nodes.
    * @since Sitevision 4.3.1
    */
-  getNonNullFilter(): Filter;
+  getNonNullFilter(): Filter<Node>;
 
   /**
    * Gets a filter that skips a given number of nodes.
@@ -231,7 +231,7 @@ export interface NodeFilterUtil {
    * @throws IllegalArgumentException if aSkip is less than zero
    * @since Sitevision 2025.01.1
    */
-  getSkipFilter(aSkip: number): Filter;
+  getSkipFilter(aSkip: number): Filter<Node>;
 
   /**
    * Gets a filter that inverts the result of another filter.
@@ -239,7 +239,7 @@ export interface NodeFilterUtil {
    * @return a filter that inverts the result
    * @throws IllegalArgumentException if <code>aFilter</code> is <code>null</code>
    */
-  getInvertedFilter(aFilter: Filter): Filter;
+  getInvertedFilter(aFilter: Filter<Node>): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified node identifier.
@@ -248,7 +248,7 @@ export interface NodeFilterUtil {
    * @throws IllegalArgumentException if <code>aIdentifier</code> is <code>null</code> or whitespace only
    * @since Sitevision 4.1
    */
-  getIdentifierFilter(aIdentifier: String | string): Filter;
+  getIdentifierFilter(aIdentifier: String | string): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified node identifier prefix.
@@ -257,7 +257,7 @@ export interface NodeFilterUtil {
    * @throws IllegalArgumentException if <code>aIdentifierPrefix</code> is <code>null</code> or whitespace only
    * @since Sitevision 4.1
    */
-  getIdentifierPrefixFilter(aIdentifierPrefix: String | string): Filter;
+  getIdentifierPrefixFilter(aIdentifierPrefix: String | string): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified node identifier suffix.
@@ -266,7 +266,7 @@ export interface NodeFilterUtil {
    * @throws IllegalArgumentException if <code>aIdentifierSuffix</code> is <code>null</code> or whitespace only
    * @since Sitevision 4.1
    */
-  getIdentifierSuffixFilter(aIdentifierSuffix: String | string): Filter;
+  getIdentifierSuffixFilter(aIdentifierSuffix: String | string): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified primary node type.
@@ -277,7 +277,7 @@ export interface NodeFilterUtil {
    * @see #getNoneOfPrimaryNodeTypesFilter(Collection)
    * @see senselogic.sitevision.api.node.NodeTypeUtil
    */
-  getPrimaryNodeTypeFilter(aPrimaryNodeTypeName: String | string): Filter;
+  getPrimaryNodeTypeFilter(aPrimaryNodeTypeName: String | string): Filter<Node>;
 
   /**
    * Gets a filter that matches all nodes that has a primary node type that is present in given collection.
@@ -295,7 +295,7 @@ export interface NodeFilterUtil {
    */
   getAnyOfPrimaryNodeTypesFilter(
     aPrimaryNodeTypeNames: Collection | unknown[]
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches all nodes that does not have a primary node type present in given collection.
@@ -314,7 +314,7 @@ export interface NodeFilterUtil {
    */
   getNoneOfPrimaryNodeTypesFilter(
     aExcludedPrimaryNodeTypeNames: Collection | unknown[]
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the existence of a specified property.
@@ -323,7 +323,7 @@ export interface NodeFilterUtil {
    * @throws IllegalArgumentException if <code>aPropertyName</code> is <code>null</code> or whitespace only
    * @see javax.jcr.Node#hasProperty(String)
    */
-  getHasPropertyFilter(aPropertyName: String | string): Filter;
+  getHasPropertyFilter(aPropertyName: String | string): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified string property.
@@ -336,7 +336,7 @@ export interface NodeFilterUtil {
   getStringPropertyFilter(
     aPropertyName: String | string,
     aMatchValue: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified multi-valued string property.
@@ -349,7 +349,7 @@ export interface NodeFilterUtil {
   getStringMultiPropertyFilter(
     aPropertyName: String | string,
     aMatchValue: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches case-insensitive by a specified string property.
@@ -361,7 +361,7 @@ export interface NodeFilterUtil {
   getIgnoreCaseStringPropertyFilter(
     aPropertyName: String | string,
     aCaseInsensitiveValue: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the value-starts-with of a specified string property.
@@ -377,7 +377,7 @@ export interface NodeFilterUtil {
   getStartsWithStringPropertyFilter(
     aPropertyName: String | string,
     aStartsWithValue: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the value-ends-with of a specified string property.
@@ -393,7 +393,7 @@ export interface NodeFilterUtil {
   getEndsWithStringPropertyFilter(
     aPropertyName: String | string,
     aEndsWithValue: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the value-contains of a specified string property.
@@ -409,7 +409,7 @@ export interface NodeFilterUtil {
   getContainsStringPropertyFilter(
     aPropertyName: String | string,
     aContainsValue: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the value-contains of a specified multi-valued string property.
@@ -425,7 +425,7 @@ export interface NodeFilterUtil {
   getContainsStringMultiPropertyFilter(
     aPropertyName: String | string,
     aContainsValue: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a regular expression of a specified string property.
@@ -444,7 +444,7 @@ export interface NodeFilterUtil {
   getPatternStringPropertyFilter(
     aPropertyName: String | string,
     aRegularExpression: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a regular expression of a specified multi-valued string property.
@@ -463,7 +463,7 @@ export interface NodeFilterUtil {
   getPatternStringMultiPropertyFilter(
     aPropertyName: String | string,
     aRegularExpression: String | string
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified boolean property.
@@ -476,7 +476,7 @@ export interface NodeFilterUtil {
   getBooleanPropertyFilter(
     aPropertyName: String | string,
     aMatchValue: boolean
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a nested node's specified boolean property.
@@ -491,7 +491,7 @@ export interface NodeFilterUtil {
     aNodePropertyName: String | string,
     aPropertyName: String | string,
     aMatchValue: boolean
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified int property.
@@ -504,7 +504,7 @@ export interface NodeFilterUtil {
   getIntPropertyFilter(
     aPropertyName: String | string,
     aMatchValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the min value of a specified int property.
@@ -516,7 +516,7 @@ export interface NodeFilterUtil {
   getMinIntPropertyFilter(
     aPropertyName: String | string,
     aMinValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the max value of a specified int property.
@@ -528,7 +528,7 @@ export interface NodeFilterUtil {
   getMaxIntPropertyFilter(
     aPropertyName: String | string,
     aMaxValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the range of a specified int property.
@@ -547,7 +547,7 @@ export interface NodeFilterUtil {
     aPropertyName: String | string,
     aMinValue: number,
     aMaxValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a nested node's specified int property.
@@ -562,7 +562,7 @@ export interface NodeFilterUtil {
     aNodePropertyName: String | string,
     aPropertyName: String | string,
     aMatchValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a nested node's min value of a specified int property.
@@ -577,7 +577,7 @@ export interface NodeFilterUtil {
     aNodePropertyName: String | string,
     aPropertyName: String | string,
     aMinValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a nested node's max value of a specified int property.
@@ -592,7 +592,7 @@ export interface NodeFilterUtil {
     aNodePropertyName: String | string,
     aPropertyName: String | string,
     aMaxValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a nested node's range of a specified int property.
@@ -613,7 +613,7 @@ export interface NodeFilterUtil {
     aPropertyName: String | string,
     aMinValue: number,
     aMaxValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified double property.
@@ -626,7 +626,7 @@ export interface NodeFilterUtil {
   getDoublePropertyFilter(
     aPropertyName: String | string,
     aMatchValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a nested node's specified double property.
@@ -641,7 +641,7 @@ export interface NodeFilterUtil {
     aNodePropertyName: String | string,
     aPropertyName: String | string,
     aMatchValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the min value of a specified double property.
@@ -653,7 +653,7 @@ export interface NodeFilterUtil {
   getMinDoublePropertyFilter(
     aPropertyName: String | string,
     aMinValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the max value of a specified double property.
@@ -665,7 +665,7 @@ export interface NodeFilterUtil {
   getMaxDoublePropertyFilter(
     aPropertyName: String | string,
     aMaxValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the range of a specified double property.
@@ -684,7 +684,7 @@ export interface NodeFilterUtil {
     aPropertyName: String | string,
     aMinValue: number,
     aMaxValue: number
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a specified Calendar property.
@@ -697,7 +697,7 @@ export interface NodeFilterUtil {
   getCalendarPropertyFilter(
     aPropertyName: String | string,
     aMatchValue: Calendar
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a nested node's specified Calendar property.
@@ -712,7 +712,7 @@ export interface NodeFilterUtil {
     aNodePropertyName: String | string,
     aPropertyName: String | string,
     aMatchValue: Calendar
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a before value for a specified Calendar property.
@@ -724,7 +724,7 @@ export interface NodeFilterUtil {
   getBeforeCalendarPropertyFilter(
     aPropertyName: String | string,
     aBeforeThresholdValue: Calendar
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by a before value of a nested node's specified Calendar property.
@@ -738,7 +738,7 @@ export interface NodeFilterUtil {
     aNodePropertyName: String | string,
     aPropertyName: String | string,
     aBeforeThresholdValue: Calendar
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by an after value for a specified Calendar property.
@@ -750,7 +750,7 @@ export interface NodeFilterUtil {
   getAfterCalendarPropertyFilter(
     aPropertyName: String | string,
     aAfterThresholdValue: Calendar
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by an after value of a nested node's specified Calendar property.
@@ -764,7 +764,7 @@ export interface NodeFilterUtil {
     aNodePropertyName: String | string,
     aPropertyName: String | string,
     aAfterThresholdValue: Calendar
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the between range of a specified Calendar property.
@@ -784,7 +784,7 @@ export interface NodeFilterUtil {
     aPropertyName: String | string,
     aAfterThresholdValue: Calendar,
     aBeforeThresholdValue: Calendar
-  ): Filter;
+  ): Filter<Node>;
 
   /**
    * Gets a filter that matches by the between range of a nested node's specified Calendar property.
@@ -806,7 +806,7 @@ export interface NodeFilterUtil {
     aPropertyName: String | string,
     aAfterThresholdValue: Calendar,
     aBeforeThresholdValue: Calendar
-  ): Filter;
+  ): Filter<Node>;
 }
 
 declare namespace NodeFilterUtil {}

--- a/packages/api/src/public-api/server/NodeIteratorUtil/index.d.ts
+++ b/packages/api/src/public-api/server/NodeIteratorUtil/index.d.ts
@@ -50,7 +50,7 @@ export interface NodeIteratorUtil {
    */
   getFilteredNodeIterator(
     aNodeIterator: NodeIterator,
-    aFilter: Filter
+    aFilter: Filter<Node>
   ): NodeIterator;
 
   /**
@@ -151,7 +151,7 @@ export interface NodeIteratorUtil {
    * @return first node that matches <code>aFilter</code>, or <code>null</code>.&#xA; If <code>aFilter</code> is <code>null</code>, the filter will be ignored (all nodes will be accepted).&#xA; If <code>aNodeIterator</code> is <code>null</code>, <code>null</code> will be returned.
    * @since Sitevision 3.6.2
    */
-  findFirst(aNodeIterator: NodeIterator, aFilter: Filter): Node;
+  findFirst(aNodeIterator: NodeIterator, aFilter: Filter<Node>): Node;
 
   /**
    * Gets a max-sized node list from a node iterator that matches a specified filter.
@@ -168,7 +168,7 @@ export interface NodeIteratorUtil {
    * @return a list of nodes that matches <code>aFilter</code>, never <code>null</code>.&#xA; The list will contain at most aLimit nodes.&#xA; If aNodeIterator is null, an empty list will be returned.&#xA; If aFilter is null, the filter will be ignored (all nodes will be accepted).&#xA; If aLimit is negative or zero, an empty list will be returned.
    * @since Sitevision 3.6.2
    */
-  findNodes(aNodeIterator: NodeIterator, aFilter: Filter, aLimit: number): List;
+  findNodes(aNodeIterator: NodeIterator, aFilter: Filter<Node>, aLimit: number): List;
 
   /**
    * Gets a max-sized node list from a node iterator that matches a specified filter, skipping a specified number of matching nodes.
@@ -190,7 +190,7 @@ export interface NodeIteratorUtil {
    */
   findMoreNodes(
     aNodeIterator: NodeIterator,
-    aFilter: Filter,
+    aFilter: Filter<Node>,
     aSkip: number,
     aLimit: number
   ): List;
@@ -214,7 +214,7 @@ export interface NodeIteratorUtil {
    * @return a list of nodes that matches <code>aFilter</code>, never <code>null</code>.&#xA; If <code>aFilter</code> is <code>null</code>, the filter will be ignored (all nodes will be accepted).&#xA; If <code>aNodeIterator</code> is <code>null</code>, an empty list will be returned.
    * @since Sitevision 3.6.2
    */
-  findAll(aNodeIterator: NodeIterator, aFilter: Filter): List;
+  findAll(aNodeIterator: NodeIterator, aFilter: Filter<Node>): List;
 
   /**
    * Gets a list of all nodes of a node iterator.
@@ -253,7 +253,7 @@ export interface NodeIteratorUtil {
    * @since Sitevision 3.6.3
    * @see senselogic.sitevision.api.node.NodeFilterUtil#split(java.util.Collection, senselogic.sitevision.api.base.Filter)
    */
-  split(aNodeIterator: NodeIterator, aFilter: Filter): FilterSplit;
+  split(aNodeIterator: NodeIterator, aFilter: Filter<Node>): FilterSplit;
 }
 
 declare namespace NodeIteratorUtil {}

--- a/packages/api/src/public-api/server/NodeTreeUtil/index.d.ts
+++ b/packages/api/src/public-api/server/NodeTreeUtil/index.d.ts
@@ -147,7 +147,7 @@ export interface NodeTreeUtil {
   findPortletsByName(
     aPageNode: Node,
     aPortletName: String | string,
-    aNodeFilter: Filter
+    aNodeFilter: Filter<Node>
   ): List;
 
   /**
@@ -238,7 +238,7 @@ export interface NodeTreeUtil {
   findPortletsByType(
     aPageNode: Node,
     aPortletType: String | string,
-    aNodeFilter: Filter
+    aNodeFilter: Filter<Node>
   ): List;
 
   /**
@@ -252,7 +252,7 @@ export interface NodeTreeUtil {
    * @return all occurrences of portlets that also applies to the aNodeFilter filter.&#xA; If no such portlets can be found or if aPageNode is not a page node, an empty List is returned
    * @since Sitevision 2023.07.1
    */
-  findPortlets(aPageNode: Node, aNodeFilter: Filter): List;
+  findPortlets(aPageNode: Node, aNodeFilter: Filter<Node>): List;
 
   /**
    * Find a layout with a specific name on a page node.
@@ -337,7 +337,7 @@ export interface NodeTreeUtil {
   findLayoutsByName(
     aPageNode: Node,
     aLayoutName: String | string,
-    aNodeFilter: Filter
+    aNodeFilter: Filter<Node>
   ): List;
 
   /**
@@ -364,7 +364,7 @@ export interface NodeTreeUtil {
    * @return all occurrences of layouts that also applies to the aNodeFilter filter.&#xA; If no such layouts can be found or if aPageNode is not a page node, an empty List is returned
    * @since Sitevision 2023.07.1
    */
-  findLayouts(aPageNode: Node, aNodeFilter: Filter): List;
+  findLayouts(aPageNode: Node, aNodeFilter: Filter<Node>): List;
 }
 
 declare namespace NodeTreeUtil {}

--- a/packages/api/src/public-api/types/senselogic/sitevision/api/base/Filter/index.d.ts
+++ b/packages/api/src/public-api/types/senselogic/sitevision/api/base/Filter/index.d.ts
@@ -13,11 +13,13 @@
  * @since Sitevision 3.6.2
  * @see senselogic.sitevision.api.node.NodeFilterUtil
  */
-export type Filter = {
-  /**
-   * Whether a given object matches the filter requirements or not.
-   * @param anObject the object to check
-   * @return <code>true</code> if <code>anObject</code> is accepted by this filter, <code>false</code> otherwise
-   */
-  accept(anObject: unknown): boolean;
-};
+export type Filter<T = unknown> =
+  | {
+      /**
+       * Whether a given object matches the filter requirements or not.
+       * @param anObject the object to check
+       * @return <code>true</code> if <code>anObject</code> is accepted by this filter, <code>false</code> otherwise
+       */
+      accept(anObject: T): boolean;
+    }
+  | ((anObject: T) => boolean);


### PR DESCRIPTION
In TypeScript you have to pass a Filter object with an accept function to satisfy the typings, which is a bit cumbersome.
It's possible to pass a simple callback as a filter, so this works in plain JavaScript:
```js
const nodes = NodeIteratorUtil.findAll(parentNode.getNodes(), (node) => node.getIdentifier() === '4.123abc');
```

I've updated the Filter type to also allow a simple callback function and added generics to specify the type of the object being filtered, so you can now do this in TS as well:

```ts
// Old approach
const filter = {
  accept(node: Node) {
    return node.getIdentifier() === '4.123abc';
  },
};

const nodes = NodeIteratorUtil.findAll(parentNode.getNodes(), filter);

// With the filter type
const filter: Filter<Node> = {
  accept(node) {
    return node.getIdentifier() === '4.123abc';
  },
};
const nodes = NodeIteratorUtil.findAll(parentNode.getNodes(), filter);

// With a callback
const nodes = NodeIteratorUtil.findAll(parentNode.getNodes(), (node) => node.getIdentifier() === '4.123abc');

```

It also aligns better with the JavaDoc which states the type of the object being filtered.

I've also updated `NodeTreeUtil`, `NodeFilterUtil`, `CompoundAndFilterBuilder` and `CompoundOrFilterBuilder` to use the generics in the Filter type.