### PR TITLE
Allow type augmentation for Request.context

### DIFF
--- a/packages/api/src/common/router/index.d.ts
+++ b/packages/api/src/common/router/index.d.ts
@@ -9,9 +9,13 @@ export interface Cookie {
   sameSite?: 'Strict' | 'Lax' | 'None' | undefined;
 }
 
-export type Session = {
+export interface Session {
   [key: string]: any;
 };
+
+export interface Context {
+  [key: string]: any;
+}
 
 export interface Request {
   invalidateSession(): void;
@@ -43,7 +47,7 @@ export interface Request {
   /**
    * Can be populated in a hooks context and read from a render context
    */
-  context: { [key: string]: unknown };
+  context: Context;
 }
 
 export interface Response {


### PR DESCRIPTION
The current inline type definition can't be augmented via TypeScript module augmentation. This change makes it possible to add type-safe properties to req.context when passing data from hooks to routes.

By extracting to a named `Context` interface you can now augment it:

```ts
import type { User } from './api/findUser';

declare module '@sitevision/api/common/router' {
  interface Context {
    user: User;
  }
}
```

In hooks.ts
```ts
hooks.beforeRender((req, res) => { 
  const user = findUser();
  req.context.user = user;
});
```

In index.ts
```ts
router.get('/', (req, res) => {
  const { user } = req.context;
});
```
<img width="314" height="65" alt="image" src="https://github.com/user-attachments/assets/faf63d3a-a566-4eea-af57-abf74871f9de" />

Should the `Session` be an interface as well to make augmentation possible?

I made a PR for this suggestions since I guessed this isn't part of the definitions that get generated from JavaDoc?