### PR TITLE
Fix type definitions for storage

### DIFF
--- a/packages/api/src/server/storage/index.d.ts
+++ b/packages/api/src/server/storage/index.d.ts
@@ -9,19 +9,97 @@ export interface FindOptions {
   orderBy?: OrderByOptions | OrderByOptions[];
 }
 
-export interface CollectionDataStore {
-  add(data: any): void;
-  addAll(data: any[]): void;
-  get(dsid: string): unknown;
-  set(dsid: string, data: any): void;
-  remove(dsid: string): unknown;
+export interface DataStoreMetadata {
+  dsid: string;
+  dstimestamp: number;
+}
+
+export type CollectionDataStoreItem<T = Record<string, unknown>> = T & DataStoreMetadata;
+
+/**
+ * @since 5.2
+ */
+export interface CollectionDataStore<T = Record<string, unknown>> {
+  /**
+   * Adds an item to a collection.
+   * Returns the stored item.
+   *
+   * @since 5.2
+   * @param data JSON data to store
+   */
+  add(data: T): CollectionDataStoreItem<T>;
+
+  /**
+   * Adds an array of items to a collection.
+   *
+   * @since 5.2
+   * @param data An array of objects to store
+   */
+  addAll(data: T[]): CollectionDataStoreItem<T>[];
+
+  /**
+   * Gets a specific item in a collection.
+   *
+   * @since 5.2
+   * @param dsid The dsid to identify the item to retrieve data from
+   */
+  get(dsid: string): CollectionDataStoreItem<T>;
+
+  /**
+   * Updates a specific item in a collection (partial update).
+   * Returns the stored item.
+   *
+   * If a property value in the data is set to null, the property will be removed.
+   *
+   * @since 5.2
+   * @param dsid The dsid to identify the item to update
+   * @param data JSON data to update the item
+   */
+  set(dsid: string, data: T): CollectionDataStoreItem<T>;
+
+  /**
+   * Removes a specific item in a collection.
+   * Returns the removed item.
+   *
+   * @since 5.2
+   * @param dsid The dsid to identify the item to remove
+   */
+  remove(dsid: string): CollectionDataStoreItem<T>;
+
+  /**
+   * Removes all items in a collection.
+   *
+   * @since 5.2
+   */
   removeAll(): void;
 
-  find(query: string, options?: FindOptions): SearchResult;
   /**
-   * @deprecated
+   * Returns a search result, potentially in a custom sort order.
+   *
+   * Queries use Solr query syntax. First level data is asynchronously indexed — index fields are
+   * prefixed with their type: `ds.analyzed.<key>`, `ds.double.<key>`, `ds.sortable.<key>`.
+   *
+   * Results are always sorted. If no `orderBy` is given, results are sorted by the modified field
+   * (last updated first).
+   *
+   * Match-all queries (`*`, `*:*`) bypass the index and iterate the data store directly
+   * if no explicit `orderBy` is specified.
+   *
+   * @since 8.1
+   * @param query The search query (Solr query syntax)
+   * @param options Optional count, skip and orderBy
    */
-  find(query: string, count?: number, skip?: number): SearchResult;
+  find(query: string, options?: FindOptions): SearchResult<CollectionDataStoreItem<T>>;
+
+  /**
+   * Returns a search result.
+   *
+   * @deprecated Use `find(query, options)` instead.
+   * @param query The search query (Solr query syntax)
+   * @param count Maximum number of hits to return (default: 10)
+   * @param skip Number of leading hits to be skipped (default: 0)
+   */
+  find(query: string, count?: number, skip?: number): SearchResult<CollectionDataStoreItem<T>>;
 
   /**
    * Performs instant indexing (blocking) of a collection data store post.
@@ -31,15 +109,15 @@ export interface CollectionDataStore {
    * Note! The blocking "index now" operation will only be performed on the index of the local cluster node! Indexes on other cluster nodes still relies on the asynchronous indexing triggered by data mutations!
    *
    * @since 6.1
-   * @param disd The dsid to identify the item to instantly index
+   * @param dsid The dsid to identify the item to instantly index
    */
-  instantIndex(disd: string): void;
+  instantIndex(dsid: string): void;
 }
 
 /**
  * @since 5.2
  */
-export interface KeyValueDataStore {
+export interface KeyValueDataStore<T = Record<string, unknown>> {
   /**
    * Stores data associated with a key.
    * Returns current data stored on the key.
@@ -48,15 +126,14 @@ export interface KeyValueDataStore {
    * @param key A key to uniquely identify the record
    * @param data  Data to store
    */
-  put(key: string, data: any): void;
-
+  put(key: string, data: T): T | null;
   /**
    * Returns data associated with a key.
    *
    * @since 5.2
    * @param key A key to retrieve data from
    */
-  get(key: string): unknown;
+  get(key: string): T | null;
 
   /**
    * Removes data associated with a key.
@@ -65,16 +142,43 @@ export interface KeyValueDataStore {
    * @since 5.2
    * @param key A key to identify data to remove
    */
-  remove(key: string): void;
+  remove(key: string): T | null;
 }
 
-export interface SearchResult {
-  toArray(): unknown[];
+export interface SearchResult<T = unknown> {
+  /**
+   * Gets an array of items from the search result.
+   *
+   * @since 5.2
+   */
+  toArray(): T[];
+
+  /**
+   * Calls the supplied callback for every item in the result.
+   *
+   * @param callback Called for each item. First parameter is an error object if an error occurred, undefined otherwise. Second parameter is the item.
+   */
   each(
-    callback: (err: DataStoreError | undefined, data: unknown) => void
+    callback: (err: DataStoreError | undefined, data: T) => void
   ): void;
+
+  /**
+   * Returns a boolean indicating whether there are available items in the search result iterator.
+   */
   hasNext(): boolean;
-  next(): unknown;
+
+  /**
+   * Reads one item at a time from the result iterator.
+   *
+   * @since 5.2
+   */
+  next(): T;
+
+  /**
+   * Get the number of items in the search result.
+   *
+   * @param callback Called after execution. First parameter is an error object if an error occurred, undefined otherwise. Second parameter is the number of hits.
+   */
   length(
     callback: (err: DataStoreError | undefined, length: number) => void
   ): void;
@@ -100,13 +204,13 @@ export interface Storage {
    * Get an instance of a CollectionDataStore
    * @param identifier The name of a data store
    */
-  getCollectionDataStore(identifier: string): CollectionDataStore;
+  getCollectionDataStore<T = Record<string, unknown>>(identifier: string): CollectionDataStore<T>;
 
   /**
    * Get an instance of a KeyValueDataStore
    * @param identifier The name of a data store
    */
-  getKeyValueDataStore(identifier: string): KeyValueDataStore;
+  getKeyValueDataStore<T = Record<string, unknown>>(identifier: string): KeyValueDataStore<T>;
 }
 
 declare namespace Storage {}

--- a/packages/api/src/server/storage/index.d.ts
+++ b/packages/api/src/server/storage/index.d.ts
@@ -35,7 +35,7 @@ export interface CollectionDataStore<T = Record<string, unknown>> {
    * @since 5.2
    * @param data An array of objects to store
    */
-  addAll(data: T[]): CollectionDataStoreItem<T>[];
+  addAll(data: T[]): void;
 
   /**
    * Gets a specific item in a collection.


### PR DESCRIPTION
Noticed that some the type definitions for `CollectionDataStore` and `KeyValueDataStore` isn't correct.
Several of the functions were typed to return void but in fact they return the created or modified item.
I also added the possibility to pass a generic when instansiating a store for better typing when using the store and removing the need to cast the returned values. 
Also added JSDoc that was missing from the documentation on https://developer.sitevision.se/

## Examples

### Collection data store

Can now pass a typegeneric so that `add`, `set`, `get`, `find` etc. are fully typed.
Return values from the API are typed as `T & DataStoreMetadata`, exposed via the `CollectionDataStoreItem<T>` helper type.
```ts
type FeedbackEntry = {
  message: string;
  rating: number;
};

const store = storage.getCollectionDataStore<FeedbackEntry>('feedback');

// add / set accept T — metadata fields cannot be passed
store.add({ message: 'Great service!', rating: 5 });
store.set(item.dsid, { rating: 4 }); // partial update

// get / find return T & DataStoreMetadata
const item = store.get('some-dsid');
item.message;      // string
item.dsid;         // string  (from DataStoreMetadata)
item.dstimestamp;  // number  (from DataStoreMetadata)
// find returns SearchResult<T & DataStoreMetadata>
const result = store.find('*:*', { count: 20 });
const items = result.toArray(); // FeedbackEntry & DataStoreMetadata[]
```
<img width="833" height="314" alt="image" src="https://github.com/user-attachments/assets/a72fc7bd-b3f0-47dc-ae05-4174f6e5bf04" />

Without a generic it falls back to `Record<string, unknown>`, which still gives you `dsid` and `dstimestamp` via `DataStoreMetadata`:
```ts
const generic = storage.getCollectionDataStore('myStore');
const item = generic.get('some-dsid');
item.dsid;         // string
item['anyKey'];    // unknown
```
<img width="916" height="106" alt="image" src="https://github.com/user-attachments/assets/65f62535-f363-4bc7-929a-90759df51241" />

### Key-value data store
Can now pass a type generic, haven't tested this as extensivly as the collection store.
Return types were also corrected based on the documentation:
```ts
type Config = {
  foo: string;
  num: number;
};

const store = storage.getKeyValueDataStore<Config>('config');
store.put('settings', { foo: 'bar', num: 25 });

const config = store.get('settings');  // Config | null
if (config) {
  config.foo; // string
}
const removed = store.remove('settings'); // Config| null
```