### PR TITLE
Add add-on info to manifest and README

### DIFF
--- a/packages/sitevision-scripts/config/setup-questions.js
+++ b/packages/sitevision-scripts/config/setup-questions.js
@@ -48,6 +48,14 @@ export const questions = [
     message: 'Development addon name',
   },
   {
+    name: 'description',
+    message: 'Development addon description',
+  },
+  {
+    name: 'author',
+    message: 'Author',
+  },
+  {
     name: 'username',
     message: 'Username for development site',
   },

--- a/packages/sitevision-scripts/scripts/init.js
+++ b/packages/sitevision-scripts/scripts/init.js
@@ -180,6 +180,8 @@ export default async ({ appPath, appName }) => {
         domain,
         siteName,
         addonName,
+        description,
+        author,
         username,
         password,
         typescript,
@@ -210,6 +212,9 @@ export default async ({ appPath, appName }) => {
         console.log(`Initializing Sitevision ${type} app`, appName);
         const templateOptions = {
           appName,
+          addonName,
+          description,
+          author,
         };
 
         switch (type) {

--- a/packages/sitevision-scripts/scripts/setup-dev-properties.js
+++ b/packages/sitevision-scripts/scripts/setup-dev-properties.js
@@ -6,7 +6,9 @@ import { questions } from '../config/setup-questions.js';
 
 (function () {
   let existingDevProperties;
-  let setupQuestions = questions.filter((q) => q.name !== 'type');
+  let setupQuestions = questions.filter(
+    (q) => !['type', 'description', 'author'].includes(q.name)
+  );
 
   try {
     existingDevProperties = properties.getDevProperties();

--- a/packages/sitevision-scripts/template/rest-bundled-typescript/README.md
+++ b/packages/sitevision-scripts/template/rest-bundled-typescript/README.md
@@ -1,6 +1,6 @@
-# restapp-boilerplate
+# {{addonName}}
 
-Boilerplate code for a simple RESTApp
+{{description}}
 
 ## Developing
 

--- a/packages/sitevision-scripts/template/rest-bundled-typescript/manifest.json
+++ b/packages/sitevision-scripts/template/rest-bundled-typescript/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "{{appName}}",
   "version": "0.0.1",
-  "name": "RESTApp boilerplate",
-  "author": "My Company",
-  "description": "A RESTApp boilerplate",
+  "name": "{{addonName}}",
+  "author": "{{author}}",
+  "description": "{{description}}",
   "helpUrl": "https://example.com/restapps",
   "type": "RESTApp",
   "bundled": true,

--- a/packages/sitevision-scripts/template/rest-bundled/README.md
+++ b/packages/sitevision-scripts/template/rest-bundled/README.md
@@ -1,6 +1,6 @@
-# restapp-boilerplate
+# {{addonName}}
 
-Boilerplate code for a simple RESTApp
+{{description}}
 
 ## Developing
 

--- a/packages/sitevision-scripts/template/rest-bundled/manifest.json
+++ b/packages/sitevision-scripts/template/rest-bundled/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "{{appName}}",
   "version": "0.0.1",
-  "name": "RESTApp boilerplate",
-  "author": "My Company",
-  "description": "A RESTApp boilerplate",
+  "name": "{{addonName}}",
+  "author": "{{author}}",
+  "description": "{{description}}",
   "helpUrl": "https://example.com/restapps",
   "type": "RESTApp",
   "bundled": true,

--- a/packages/sitevision-scripts/template/web-react-typescript/README.md
+++ b/packages/sitevision-scripts/template/web-react-typescript/README.md
@@ -1,6 +1,6 @@
-# webapp-boilerplate
+# {{addonName}}
 
-Boilerplate code for a simple WebApp
+{{description}}
 
 ## Developing
 

--- a/packages/sitevision-scripts/template/web-react-typescript/manifest.json.template
+++ b/packages/sitevision-scripts/template/web-react-typescript/manifest.json.template
@@ -2,11 +2,11 @@
   "id": "{{appName}}",
   "version": "0.0.1",
   "name": {
-    "en": "{{manifestType}} boilerplate"
+    "en": "{{addonName}}"
   },
-  "author": "My Company",
+  "author": "{{author}}",
   "description": {
-    "en": "A {{manifestType}} boilerplate"
+    "en": "{{description}}"
   },
   "helpUrl": "https://example.com/webapps",
   "type": "{{manifestType}}",

--- a/packages/sitevision-scripts/template/web-react/README.md
+++ b/packages/sitevision-scripts/template/web-react/README.md
@@ -1,6 +1,6 @@
-# webapp-boilerplate
+# {{addonName}}
 
-Boilerplate code for a simple WebApp
+{{description}}
 
 ## Developing
 

--- a/packages/sitevision-scripts/template/web-react/manifest.json.template
+++ b/packages/sitevision-scripts/template/web-react/manifest.json.template
@@ -2,11 +2,11 @@
   "id": "{{appName}}",
   "version": "0.0.1",
   "name": {
-    "en": "{{manifestType}} boilerplate"
+    "en": "{{addonName}}"
   },
-  "author": "My Company",
+  "author": "{{author}}",
   "description": {
-    "en": "A {{manifestType}} boilerplate"
+    "en": "{{description}}"
   },
   "helpUrl": "https://example.com/webapps",
   "type": "{{manifestType}}",


### PR DESCRIPTION
## Summary

This commit replaces the boilerplate text in `manifest.json` and `README.md` with information provided during the setup questions.

This makes the generated add-on templates contain the provided information from the start instead of requiring the boilerplate text to be replaced manually.